### PR TITLE
Fix blog liking

### DIFF
--- a/apps/foundation/pages/blog/[slug].tsx
+++ b/apps/foundation/pages/blog/[slug].tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, dehydrate } from '@tanstack/react-query'
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next'
 import { useRouter } from 'next/router'
 import { serialize } from 'next-mdx-remote/serialize'
@@ -17,13 +17,7 @@ import { Layout } from '../../components'
 
 type BlogPageProps = InferGetServerSidePropsType<typeof getServerSideProps>
 
-const BlogDetailPage: FC<BlogPageProps> = ({
-  seo,
-  blog,
-  queryKey,
-  authorBlogs,
-  source,
-}) => {
+const BlogDetailPage: FC<BlogPageProps> = ({ seo, authorBlogs, source }) => {
   const {
     locale,
     query: { slug },
@@ -39,13 +33,7 @@ const BlogDetailPage: FC<BlogPageProps> = ({
     <ReCaptchaProvider reCaptchaKey={RECAPTCHA_SITE_KEY}>
       <Layout seo={seo}>
         <Container maxW="container.md">
-          <BlogDetail
-            post={blog}
-            queryKey={queryKey}
-            source={source}
-            link={link}
-            authorBlogs={authorBlogs}
-          />
+          <BlogDetail source={source} link={link} authorBlogs={authorBlogs} />
         </Container>
       </Layout>
     </ReCaptchaProvider>
@@ -81,11 +69,10 @@ export const getServerSideProps = async (
 
   return {
     props: {
-      blog,
       seo,
       source,
-      queryKey,
       authorBlogs,
+      dehydratedState: dehydrate(queryClient),
       ...(await ssrTranslations(locale)),
     },
   }

--- a/packages/services/src/blog/getBlogBySlug.ts
+++ b/packages/services/src/blog/getBlogBySlug.ts
@@ -8,7 +8,7 @@ import { Blog, StrapiLocale } from '@fc/types'
 export const getBlogBySlug = async (
   locale: StrapiLocale,
   slug: string,
-): Promise<Blog | null> => {
+): Promise<Blog> => {
   const response = await strapiRequest<
     SetRequired<Blog, 'author' | 'image' | 'likers'>
   >({
@@ -21,11 +21,11 @@ export const getBlogBySlug = async (
   return response?.data?.[0] || null
 }
 
-export const useGetBlogSlug = (slug: string) => {
-  const { locale } = useRouter()
+export const useGetBlogSlug = () => {
+  const { locale, query } = useRouter()
 
   return useQuery({
-    queryKey: ['blog', locale, slug],
-    queryFn: () => getBlogBySlug(locale as StrapiLocale, slug),
+    queryKey: ['blog', locale, query.slug],
+    queryFn: () => getBlogBySlug(locale as StrapiLocale, query.slug as string),
   })
 }

--- a/packages/services/src/blog/like.ts
+++ b/packages/services/src/blog/like.ts
@@ -1,11 +1,14 @@
-import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { useMutation } from '@tanstack/react-query'
 import axios from 'axios'
 import { useLocalStorage } from 'usehooks-ts'
 
 import { API_URL } from '@fc/config'
 import { useAuthContext } from '@fc/context'
-import { Blog, LikeMutationArgs } from '@fc/types'
+import { LikeMutationArgs } from '@fc/types'
 
+import { useGetBlogSlug } from './getBlogBySlug'
 import { useRecaptchaToken } from '../common'
 
 const useLikeBlogMutation = () => {
@@ -23,8 +26,9 @@ const useLikeBlogMutation = () => {
   })
 }
 
-export const useLikeBlog = (blog?: Blog | null, queryKey?: QueryKey) => {
-  const queryClient = useQueryClient()
+export const useLikeBlog = () => {
+  const [isDisabled, setIsDisabled] = useState(false)
+  const { data: blog, refetch } = useGetBlogSlug()
 
   const { profile } = useAuthContext()
 
@@ -45,37 +49,49 @@ export const useLikeBlog = (blog?: Blog | null, queryKey?: QueryKey) => {
 
   const isLikedStorage = likersStorage?.some(id => id === blog.id)
 
+  const handleError = (error: any) => {
+    console.error('LIKE_BLOG_ERROR', error)
+    if (error.response.status === 403) {
+      setIsDisabled(true)
+    }
+  }
+
   const toggleLike = async () => {
     if (profile) {
       return likeBlogMutation.mutate(
         { id: blog.id, type: isLikedByUser ? 'unlike' : 'like' },
         {
           onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey })
+            refetch()
           },
-        },
-      )
-    } else {
-      return likeBlogMutation.mutate(
-        { id: blog.id, type: isLikedStorage ? 'unlike' : 'like' },
-        {
-          onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey })
-
-            const updatedStorage = isLikedStorage
-              ? likersStorage?.filter(id => id !== blog.id)
-              : [...(likersStorage || []), blog.id]
-
-            setLikersStorage(updatedStorage as number[])
-          },
+          onError: handleError,
         },
       )
     }
+
+    return likeBlogMutation.mutate(
+      { id: blog.id, type: isLikedStorage ? 'unlike' : 'like' },
+      {
+        onSuccess: async () => {
+          const updatedStorage = isLikedStorage
+            ? likersStorage?.filter(id => id !== blog.id)
+            : [...(likersStorage || []), blog.id]
+
+          setLikersStorage(updatedStorage as number[])
+
+          await refetch()
+        },
+        onError: handleError,
+      },
+    )
   }
+
+  const isLiked = profile ? isLikedByUser : isLikedStorage
 
   return {
     toggleLike,
-    isLiked: profile ? isLikedByUser : isLikedStorage,
+    isLiked,
     isLoading: likeBlogMutation.isPending,
+    isDisabled,
   }
 }

--- a/packages/services/src/blog/view.ts
+++ b/packages/services/src/blog/view.ts
@@ -1,6 +1,5 @@
 import { useTimeout } from '@chakra-ui/react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/router'
+import { useMutation } from '@tanstack/react-query'
 import { useLocalStorage } from 'usehooks-ts'
 
 import { useAuthContext } from '@fc/context'
@@ -16,15 +15,9 @@ export const viewBlog = async (blog: Blog, token: string) => {
 }
 
 export const useViewBlog = () => {
-  const queryClient = useQueryClient()
-  const {
-    locale,
-    query: { slug },
-  } = useRouter()
-
   const { token } = useAuthContext()
 
-  const { data: blog } = useGetBlogSlug(slug as string)
+  const { data: blog, refetch } = useGetBlogSlug()
 
   const [blogStorage, setBlogStorage] = useLocalStorage<number[]>(
     'view-blog',
@@ -32,11 +25,11 @@ export const useViewBlog = () => {
   )
 
   const { mutate } = useMutation({
-    mutationKey: ['viewblog', blog?.id],
+    mutationKey: ['view-blog', blog?.id],
     mutationFn: (blog: Blog) => viewBlog(blog, token as string),
     onSuccess: () => {
       blog && setBlogStorage([...(blogStorage || []), blog.id])
-      queryClient.invalidateQueries({ queryKey: ['blog', locale, slug] })
+      refetch()
     },
   })
 

--- a/packages/ui/src/components/BlogDetail/BlogDetail.stories.tsx
+++ b/packages/ui/src/components/BlogDetail/BlogDetail.stories.tsx
@@ -1,19 +1,27 @@
-import { useEffect, useState } from 'react'
-
-import { StoryFn, Meta, StoryObj } from '@storybook/react'
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
 import { useRouter } from 'next/router'
-import { MDXRemoteSerializeResult } from 'next-mdx-remote'
-import { serialize } from 'next-mdx-remote/serialize'
 
 import { SITE_URL } from '@fc/config'
 import { BLOG_MOCKS } from '@fc/mocks'
 
-import { BlogDetail, BlogDetailProps } from './BlogDetail'
+import BlogDetail, { BlogDetailProps } from './BlogDetail'
 import { Container } from '../Container'
 
 export default {
   component: BlogDetail,
   title: 'Shared/BlogDetail',
+  parameters: {
+    nextjs: {
+      router: {
+        pathname: '/blog/[slug]',
+        asPath: '/blog/dimitri-1',
+        locale: 'tr',
+        query: {
+          slug: 'dimitri-1',
+        },
+      },
+    },
+  },
   args: {
     post: BLOG_MOCKS.tr.data[1],
     authorBlogs: BLOG_MOCKS.tr.data,
@@ -33,21 +41,14 @@ export default {
 type Story = StoryObj<BlogDetailProps>
 
 const StoryWithHook: StoryFn<BlogDetailProps> = args => {
-  const { locale } = useRouter()
-  const [source, setSource] = useState<MDXRemoteSerializeResult>()
+  const {
+    locale,
+    query: { slug },
+  } = useRouter()
 
-  const getSource = async (content: string) => {
-    const s = await serialize(content || '')
-    setSource(s)
-  }
+  const link = `${SITE_URL}/${locale}/blog/${slug}`
 
-  useEffect(() => {
-    getSource(args.post?.content || '')
-  }, [args.post.content])
-
-  const link = `${SITE_URL}/${locale}/blog/${args.post.slug}`
-
-  return <BlogDetail {...args} source={source!} link={link} />
+  return <BlogDetail {...args} link={link} />
 }
 
 export const Default: Story = {

--- a/packages/ui/src/components/BlogDetail/BlogDetail.tsx
+++ b/packages/ui/src/components/BlogDetail/BlogDetail.tsx
@@ -17,7 +17,7 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { AiFillHeart } from 'react-icons/ai'
 import { FaCalendarDay, FaClock, FaEye } from 'react-icons/fa'
 
-import { useLikeBlog } from '@fc/services'
+import { useGetBlogSlug, useLikeBlog } from '@fc/services'
 import { Blog, UploadFile } from '@fc/types'
 import { getReadingTime } from '@fc/utils'
 
@@ -28,30 +28,24 @@ import { ShareButtons } from '../ShareButtons'
 import { WImage } from '../WImage'
 
 export type BlogDetailProps = {
-  post: Blog
-  queryKey: string[]
   link: string
   source: MDXRemoteSerializeResult
   authorBlogs: Blog[]
 }
 
-export const BlogDetail: FC<BlogDetailProps> = ({
-  post,
-  queryKey,
-  link,
-  source,
-  authorBlogs,
-}) => {
+const BlogDetail: FC<BlogDetailProps> = ({ link, source, authorBlogs }) => {
   const { locale } = useRouter()
   const { t } = useTranslation()
 
-  const { isLiked, toggleLike } = useLikeBlog(post, queryKey)
+  const { data: post } = useGetBlogSlug()
 
-  const readingTime = getReadingTime(post.content || '', locale)
+  const { isLiked, toggleLike, isLoading, isDisabled } = useLikeBlog()
+
+  const readingTime = getReadingTime(post?.content || '', locale)
 
   return (
     <Stack py={8} spacing={8}>
-      <WImage ratio="twitter" rounded="lg" src={post.image as UploadFile} />
+      <WImage ratio="twitter" rounded="lg" src={post?.image as UploadFile} />
       <Heading as="h1" textAlign="center">
         {post?.title}
       </Heading>
@@ -65,7 +59,7 @@ export const BlogDetail: FC<BlogDetailProps> = ({
           <Box>
             <HStack>
               <Icon as={FaCalendarDay} />
-              <FormattedDate date={post.publishedAt as string} />
+              <FormattedDate date={post?.publishedAt as string} />
             </HStack>
             <HStack>
               <Icon as={FaClock} />
@@ -97,6 +91,8 @@ export const BlogDetail: FC<BlogDetailProps> = ({
             color={isLiked ? 'red.400' : 'gray.400'}
             icon={<AiFillHeart />}
             onClick={toggleLike}
+            isLoading={isLoading}
+            isDisabled={isDisabled}
           />
         </ShareButtons>
       </Wrap>
@@ -116,3 +112,5 @@ export const BlogDetail: FC<BlogDetailProps> = ({
     </Stack>
   )
 }
+
+export default BlogDetail

--- a/packages/ui/src/components/BlogDetail/index.ts
+++ b/packages/ui/src/components/BlogDetail/index.ts
@@ -1,1 +1,3 @@
-export * from './BlogDetail'
+import dynamic from 'next/dynamic'
+
+export const BlogDetail = dynamic(() => import('./BlogDetail'), { ssr: false })


### PR DESCRIPTION
I noticed we were not using react-query's hydrated state properly. The blog data was always based on server side rendering and invalidating blog queryKey was not working.

Apart from that, we use localstorage in blog detail component. To prevent hydration issue, I exported the component dynamically without server rendering.

I also disabled the like button when recaptcha or authorization issue occurs.