### PR TITLE
Burak-pm-sentence

### DIFF
--- a/packages/services/src/hashtag/getBySlug.ts
+++ b/packages/services/src/hashtag/getBySlug.ts
@@ -34,17 +34,18 @@ export const getHashtagBySlug = async (
 
   const posts =
     hashtag.posts
-      ?.filter(p => p.image || p.caps)
+      ?.filter(p => p.image || p.caps || p.imageParams)
       .map((p, index) => ({
         ...p,
         index,
-        image: {
+        image: p.image || p.caps ? {
           url:
             p.image?.formats?.small?.url ||
             p.image?.formats?.medium?.url ||
             p.image?.url ||
             p.caps?.url,
-        } as UploadFile,
+        } as UploadFile :
+          p.imageParams as UploadFile,
       })) || []
 
   const localizations = (hashtag.localizations?.map(l => ({

--- a/packages/ui/src/components/ContentEditable/ContentEditable.tsx
+++ b/packages/ui/src/components/ContentEditable/ContentEditable.tsx
@@ -21,7 +21,10 @@ export const ContentEditable: FC<ContentEditableProps> = props => {
   const contentRef = useRef<HTMLDivElement>(null)
   const caretPos = useRef<number>(0)
 
-  useDebounce(() => onUpdate(currentValue), 700, [currentValue])
+  useDebounce(() => {
+    if (contentEditable)
+      onUpdate(currentValue)
+  }, 700, [currentValue])
 
   const getCaret = (el: HTMLDivElement) => {
     let caretAt = 0


### PR DESCRIPTION
it was contenteditable after all.
at the begining it sets his currentValue with empty string (i think its happening because sentences hasnt finished fetching)
then comes real value. but then 700ms later debounce occurs and calls onupdate so it sets that sentence null. now its fixed. but only for this case.

and the changes in getBySlug, they are releated to posts that generated by PostGenAI. we set their imageparams but getBySlug filters them by image or caps. now they are ready to see after they published. (it uses hashtag's image by default)