### PR TITLE
Add push notifications

### DIFF
--- a/apps/dashboard/pages/_document.tsx
+++ b/apps/dashboard/pages/_document.tsx
@@ -26,6 +26,27 @@ export default class Document extends NextDocument {
           />
           <link rel="manifest" href="/site.webmanifest" />
           <meta name="theme-color" content="#ffffff" />
+          <script
+            src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js"
+            defer
+          ></script>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.OneSignalDeferred = window.OneSignalDeferred || [];
+            OneSignalDeferred.push(function(OneSignal) {
+              OneSignal.init({
+                appId: "580942a7-568a-4327-8abd-00d732214c81",
+                safari_web_id: "web.onesignal.auto.253751a8-ac24-4181-97da-883dbdadac49",
+                notifyButton: {
+                  enable: true,
+                },
+                allowLocalhostAsSecureOrigin: true,
+              });
+            });
+            `,
+            }}
+          ></script>
         </Head>
         <body>
           <ColorModeScript initialColorMode="light" />

--- a/apps/dashboard/public/OneSignalSDKWorker.js
+++ b/apps/dashboard/public/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts("https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js");


### PR DESCRIPTION
This commit addresses issue #618, and implements push notifications using **One Signal**. The feature is fully functional on Mozilla Firefox. However, there are some issues on other browsers:

- Google Chrome: Notification sounds are not working as expected. (MacOS 14.4.1, Chrome Version 124.0.6367.60)
- Safari: Users encounter an error when attempting to subscribe to notifications.

To test the feature:

1) Sign up at [One Signal](https://dashboard.onesignal.com/signup)
2) Create a web app on the platform
3) Activate `LOCAL TESTING` in Web Configuration (see image below)
<img width="1728" alt="image" src="https://github.com/freedomcombination/monorepo/assets/113006416/cc85c449-dad0-44f4-bc77-472894067ae3">

4) Hit "Save" and then on the following screen, copy the values of `appId` and `safari_web_id` and substitute them for the ones in the /dashboard/pages/_document.tsx file

5) Visit `localhost:3000` and click on the bell icon at the bottom-right corner of the screen, then allow notifications.

6) Go to One Signal dashboard, navigate to Messages -> Push -> New Push, then send a new notification
<img width="1728" alt="image" src="https://github.com/freedomcombination/monorepo/assets/113006416/bdea4749-2c87-4c9a-a04f-10ce2f3582fa">

7) Expected result
<img width="800" alt="image" src="https://github.com/freedomcombination/monorepo/assets/113006416/bf9978b3-e33b-42b7-89fb-9f36c8c209fc">

8) Error in Safari (shows when a user tries to subscribe to notifications)
<img width="838" alt="image" src="https://github.com/freedomcombination/monorepo/assets/113006416/23a545f6-d0a1-4466-b161-805839e6bb74">


https://github.com/freedomcombination/monorepo/assets/113006416/b1152e53-4a9c-495d-a8a8-c3839e0e24e0






