### PR TITLE
refresh observation after the sent email: fixed

### DIFF
--- a/apps/dashboard/pages/[endpoint].tsx
+++ b/apps/dashboard/pages/[endpoint].tsx
@@ -20,6 +20,7 @@ import { useStrapiRequest } from '@fc/services'
 import { ssrTranslations } from '@fc/services/ssrTranslations'
 import {
   ApprovalStatus,
+  Observation,
   Post,
   Profile,
   ProfileStatus,
@@ -150,6 +151,7 @@ const ModelPage: FC<ModelPageProps> = ({ endpoint }) => {
       enabled: !!endpoint && !!token,
     },
   })
+  // feth observation
 
   const models = endpointQuery?.data?.data
   const pageCount = endpointQuery?.data?.meta?.pagination?.pageCount
@@ -239,6 +241,14 @@ const ModelPage: FC<ModelPageProps> = ({ endpoint }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId])
 
+  const observationRequest = useStrapiRequest<Observation>({
+    endpoint: 'observations',
+    filters: { profile: { id: { $eq: selectedId } } },
+    sort: ['createdAt:desc'],
+  })
+
+  const observations = observationRequest.data?.data ?? []
+
   return (
     <AdminLayout seo={{ title }}>
       <PageHeader
@@ -309,11 +319,15 @@ const ModelPage: FC<ModelPageProps> = ({ endpoint }) => {
           {endpoint === 'profiles' && selectedModel && selectedId && (
             <ProfileContact
               profile={selectedModel as Profile}
-              onSuccess={endpointQuery.refetch}
+              onSuccess={observationRequest.refetch}
             />
           )}
           {endpoint === 'profiles' && selectedModel && selectedId && (
-            <ObservationList id={selectedId} />
+            <ObservationList
+              observations={observations}
+              onSuccess={observationRequest.refetch}
+              id={selectedId}
+            />
           )}
         </ModelEditModal>
       )}

--- a/apps/dashboard/pages/[endpoint].tsx
+++ b/apps/dashboard/pages/[endpoint].tsx
@@ -151,7 +151,6 @@ const ModelPage: FC<ModelPageProps> = ({ endpoint }) => {
       enabled: !!endpoint && !!token,
     },
   })
-  // feth observation
 
   const models = endpointQuery?.data?.data
   const pageCount = endpointQuery?.data?.meta?.pagination?.pageCount

--- a/packages/ui/src/admin/ObservationList/ObservationList.tsx
+++ b/packages/ui/src/admin/ObservationList/ObservationList.tsx
@@ -1,30 +1,24 @@
 import { Heading, Stack } from '@chakra-ui/react'
 
-import { useStrapiRequest } from '@fc/services'
 import { Observation } from '@fc/types/src/observation'
 
 import { ObservationCreateForm } from '../ObservationCreateForm'
 import { ObservationEditForm } from '../ObservationEditForm'
 
 export type ObservationListProps = {
+  onSuccess?: () => void
+  observations: Observation[]
   id: number
 }
-export const ObservationList = ({ id }: ObservationListProps) => {
-  const observationRequest = useStrapiRequest<Observation>({
-    endpoint: 'observations',
-    filters: { profile: { id: { $eq: id } } },
-    sort: ['createdAt:desc'],
-  })
-
-  const observations = observationRequest.data?.data ?? []
-
+export const ObservationList = ({
+  id,
+  observations,
+  onSuccess,
+}: ObservationListProps) => {
   return (
     <Stack p={{ base: 4, lg: 8 }} spacing={4}>
       <Heading as="h2">Observations</Heading>
-      <ObservationCreateForm
-        profileId={id}
-        onSuccess={observationRequest.refetch}
-      />
+      <ObservationCreateForm profileId={id} onSuccess={onSuccess} />
       <Stack>
         {observations?.map(observation => {
           return (
@@ -34,7 +28,7 @@ export const ObservationList = ({ id }: ObservationListProps) => {
               createdAt={observation?.createdAt}
               creator={observation?.creator || []}
               key={observation?.id}
-              onSuccess={observationRequest.refetch}
+              onSuccess={onSuccess}
             />
           )
         })}

--- a/packages/ui/src/admin/ProfileEmailForm/ProfilEmailForm.tsx
+++ b/packages/ui/src/admin/ProfileEmailForm/ProfilEmailForm.tsx
@@ -76,7 +76,7 @@ export const ProfileMailForm: FC<ProfileMailFormProps> = ({
         profile: profileId,
       } as ObservationCreateInput
 
-      mutate(body, { onSuccess })
+      mutate(body, { onSuccess: () => onSuccess?.() })
     } catch (error) {
       toastMessage(
         'Error',


### PR DESCRIPTION
There was an error when creating observation after sent email... I think It was about refreshing observations. 

First of all, creating observation is successful, but the warning say: "Something went wrong"