### PR TITLE
Fix datetime conversion to UTC before saving on hashtag page

### DIFF
--- a/packages/lib/src/mutation/mutation.ts
+++ b/packages/lib/src/mutation/mutation.ts
@@ -89,6 +89,15 @@ export const mutation = async <
   const endpointsWithoutDataField: StrapiEndpoint[] = ['users', 'users/me']
   const hasBodyDataField = !endpointsWithoutDataField.includes(endpoint)
 
+  Object.entries(body).forEach(([key, value]) => {
+    if (value instanceof Date) {
+      const utcDate = new Date(
+        value.getTime() - value.getTimezoneOffset() * 60000,
+      ).toISOString()
+      ;(body as any)[key] = utcDate
+    }
+  })
+
   let requestBody: MutationBody = hasBodyDataField
     ? ({ data: body } as { data: D })
     : body

--- a/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
+++ b/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
@@ -189,17 +189,6 @@ export const ModelEditForm = <T extends StrapiModel>({
   const onSaveModel = async (
     data: Record<string, string | File | Option | Option[]>,
   ) => {
-    // Convert the date to UTC
-    const dateValue = data['date']
-    // Convert the date to UTC if it's a Date object
-    if (dateValue instanceof Date) {
-      const utcDate = new Date(
-        dateValue.getTime() - dateValue.getTimezoneOffset() * 60000,
-      ).toISOString()
-      data['date'] = utcDate
-      console.log('Converted to UTC:', data['date'])
-    }
-
     const body = Object.entries(data).reduce((acc, [key, value]) => {
       if (value === undefined || !fields.some(f => f.name === key)) {
         return acc

--- a/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
+++ b/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
@@ -189,6 +189,17 @@ export const ModelEditForm = <T extends StrapiModel>({
   const onSaveModel = async (
     data: Record<string, string | File | Option | Option[]>,
   ) => {
+    // Convert the date to UTC
+    const dateValue = data['date']
+    // Convert the date to UTC if it's a Date object
+    if (dateValue instanceof Date) {
+      const utcDate = new Date(
+        dateValue.getTime() - dateValue.getTimezoneOffset() * 60000,
+      ).toISOString()
+      data['date'] = utcDate
+      console.log('Converted to UTC:', data['date'])
+    }
+
     const body = Object.entries(data).reduce((acc, [key, value]) => {
       if (value === undefined || !fields.some(f => f.name === key)) {
         return acc


### PR DESCRIPTION
Changes
- Added conversion of datetime fields to UTC in the `onSaveModel` function.
- Ensured that the converted datetime is in ISO format before being sent to Strapi.

Testing
- The fix has been tested both locally and in production environments to ensure that the datetime fields are saved correctly.