### PR TITLE
Refactor table columns

### DIFF
--- a/packages/ui/src/components/ExportPDF/utils.ts
+++ b/packages/ui/src/components/ExportPDF/utils.ts
@@ -156,12 +156,12 @@ export const getColumnsForPDF = <T extends StrapiModel>(
   columns: WTableRowProps<T>['columns'],
   t: TranslateFunction,
 ): string[] => {
-  return Object.keys(columns).map(key => {
-    const { label } = columns[key as keyof T] as CellConfig<T>
+  return columns.map(column => {
+    const { accessorKey, label } = column
     const translationLabel = t(
-      (label || key) as keyof I18nNamespaces['common'],
+      (label || accessorKey) as keyof I18nNamespaces['common'],
       {
-        defaultValue: label || startCase(camelCase(key)),
+        defaultValue: label || startCase(camelCase(accessorKey as string)),
       },
     )
 
@@ -182,19 +182,18 @@ export const getColumnsForPDF = <T extends StrapiModel>(
  */
 const getRowForPDF = <T extends StrapiModel>(
   model: T,
-  columns: { [key in keyof T]?: CellConfig<T> },
+  columns: Array<CellConfig<T>>,
   locale: StrapiLocale,
   t: TranslateFunction,
 ): Promise<PDFCellData[]> => {
   return Promise.all(
-    Object.keys(columns).map(async key => {
-      const field = key as keyof T
+    columns.map(async column => {
+      const field = column.accessorKey as keyof T
       const value = model[field]
-      const cell = columns[field] as CellConfig<T>
 
       const cellValue = await getCellForPDF(
         value,
-        cell,
+        column,
         field,
         model,
         locale,

--- a/packages/ui/src/components/UserRoles/UserRoles.tsx
+++ b/packages/ui/src/components/UserRoles/UserRoles.tsx
@@ -155,8 +155,9 @@ export const UserRoles = () => {
 
       <WTable
         data={roles?.data ?? []}
-        columns={{
-          id: {
+        columns={[
+          {
+            accessorKey: 'id',
             label: 'Actions',
             transform: value => {
               return (
@@ -178,13 +179,14 @@ export const UserRoles = () => {
               )
             },
           },
-          name: {},
-          type: {},
-          nb_users: {
+          { accessorKey: 'name' },
+          { accessorKey: 'type' },
+          {
+            accessorKey: 'nb_users',
             label: t('profiles'),
           },
-          description: {},
-        }}
+          { accessorKey: 'description' },
+        ]}
         onClickRow={onClickRow}
       />
     </VStack>

--- a/packages/ui/src/components/WTable/TableHeaderCell.tsx
+++ b/packages/ui/src/components/WTable/TableHeaderCell.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react'
+
+import { Th, chakra } from '@chakra-ui/react'
+import { camelCase, startCase } from 'lodash'
+import { useTranslation } from 'next-i18next'
+import { FaArrowDown, FaArrowUp, FaSort } from 'react-icons/fa6'
+
+import { StrapiModel } from '@fc/types'
+
+import { TableHeaderCellProps } from './types'
+import { I18nNamespaces } from '../../../@types/i18next'
+
+export const TableHeaderCell = <T extends StrapiModel>({
+  column,
+  index,
+  selectedIndex,
+  sortMode,
+  setSelectedIndex,
+  setSortMode,
+}: TableHeaderCellProps<T>) => {
+  const { t } = useTranslation()
+
+  const toggleSort = (index: number) => {
+    setSelectedIndex(index)
+
+    if (sortMode === 'asc') {
+      setSortMode('desc')
+    } else if (sortMode === 'desc') {
+      setSortMode(null)
+    } else if (sortMode === null) {
+      setSortMode('asc')
+    }
+  }
+
+  const { sortable, label } = column
+
+  const translationLabel = t(
+    (label || column.accessorKey) as keyof I18nNamespaces['common'],
+    {
+      defaultValue: label || startCase(camelCase(column.accessorKey as string)),
+    },
+  )
+
+  const SortIcon = useMemo(() => {
+    if (!sortable) return
+
+    if (selectedIndex === index) {
+      if (sortMode === 'asc') {
+        return FaArrowUp
+      } else if (sortMode === 'desc') {
+        return FaArrowDown
+      }
+    }
+
+    return FaSort
+  }, [index, selectedIndex, sortMode, sortable])
+
+  const onSort = () => toggleSort(index)
+
+  return (
+    <Th
+      pos="relative"
+      key={index}
+      whiteSpace="nowrap"
+      {...(sortable && {
+        cursor: 'pointer',
+        onClick: onSort,
+      })}
+    >
+      {translationLabel}
+
+      <chakra.span ml={2} display="inline" as={SortIcon} />
+    </Th>
+  )
+}

--- a/packages/ui/src/components/WTable/TableRow.tsx
+++ b/packages/ui/src/components/WTable/TableRow.tsx
@@ -2,7 +2,7 @@ import { Tr } from '@chakra-ui/react'
 
 import { StrapiModel } from '@fc/types'
 
-import { CellConfig, WTableRowProps } from './types'
+import { WTableRowProps } from './types'
 import { WTableCell } from './WTableCell'
 
 export const WTableRow = <T extends StrapiModel>({
@@ -16,20 +16,8 @@ export const WTableRow = <T extends StrapiModel>({
       onClick={() => onClick?.(modelIndex, model.id)}
       _hover={{ bg: 'blackAlpha.50', cursor: 'pointer' }}
     >
-      {Object.keys(columns).map((key, index) => {
-        const field = key as keyof T
-        const value = model[field]
-        const cell = columns[field] as CellConfig<T>
-
-        return (
-          <WTableCell
-            key={index}
-            value={value}
-            cellConfig={cell}
-            field={field}
-            model={model}
-          />
-        )
+      {columns.map((column, index) => {
+        return <WTableCell key={index} column={column} model={model} />
       })}
     </Tr>
   )

--- a/packages/ui/src/components/WTable/WTable.stories.tsx
+++ b/packages/ui/src/components/WTable/WTable.stories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 
 import { ART_MOCKS, CATEGORY_MOCKS } from '@fc/mocks'
 import {
@@ -21,9 +21,9 @@ export default {
   title: 'Shared/WTable',
 } as Meta<WTableProps<StrapiModel>>
 
-const StoryWithHooks: StoryFn<WTableProps<StrapiModel>> = args => {
+function StoryWithHooks<T extends StrapiModel>(args: WTableProps<T>) {
   const [sortKey, setSortKey] = useState<[string] | null>(null)
-  const [data, setData] = useState<StrapiModel[]>(args.data)
+  const [data, setData] = useState<T[]>(args.data)
   const initialData = useRef(data)
 
   useEffect(() => {
@@ -32,8 +32,8 @@ const StoryWithHooks: StoryFn<WTableProps<StrapiModel>> = args => {
     const [field, sort] = sortKey[0].split(':')
 
     const sortedData = [...data].sort((a, b) => {
-      const aValue = a[field as keyof StrapiModel] as StrapiModelKeys
-      const bValue = b[field as keyof StrapiModel] as StrapiModelKeys
+      const aValue = a[field as keyof T] as StrapiModelKeys
+      const bValue = b[field as keyof T] as StrapiModelKeys
 
       if (sort === 'asc') {
         return typeof aValue === 'number' && typeof bValue === 'number'
@@ -65,12 +65,16 @@ export const Arts: Story<Art> = {
   render: StoryWithHooks,
   args: {
     data: ART_MOCKS.data,
-    columns: {
-      image: {
+    columns: [
+      {
+        accessorKey: 'image',
         type: 'image',
       },
-      title_en: {}, // default type is text
-      approvalStatus: {
+      {
+        accessorKey: 'title_en',
+      }, // default type is text
+      {
+        accessorKey: 'approvalStatus',
         type: 'badge',
         // Custom props based on value
         componentProps: value => {
@@ -86,14 +90,15 @@ export const Arts: Story<Art> = {
           }
         },
       },
-      publishedAt: {
+      {
+        accessorKey: 'publishedAt',
         type: 'date',
         componentProps: {
           format: 'dd MMMM',
         },
         sortable: true,
       },
-    },
+    ],
   },
 }
 
@@ -101,11 +106,11 @@ export const Categories: Story<Category> = {
   render: StoryWithHooks,
   args: {
     data: CATEGORY_MOCKS.data,
-    columns: {
-      name_en: {},
-      name_nl: {},
-      name_tr: {},
-      slug: {},
-    },
+    columns: [
+      { accessorKey: 'name_en' },
+      { accessorKey: 'name_nl' },
+      { accessorKey: 'name_tr' },
+      { accessorKey: 'slug' },
+    ],
   },
 }

--- a/packages/ui/src/components/WTable/WTable.tsx
+++ b/packages/ui/src/components/WTable/WTable.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { chakra, Table, Tbody, Th, Thead, Tr } from '@chakra-ui/react'
-import { camelCase, startCase } from 'lodash'
-import { useTranslation } from 'next-i18next'
-import { FaArrowDown, FaArrowUp, FaSort } from 'react-icons/fa'
+import { Table, Tbody, Thead, Tr } from '@chakra-ui/react'
 
-import { StrapiModel, StrapiModelKeys } from '@fc/types'
+import { StrapiModel } from '@fc/types'
 
+import { TableHeaderCell } from './TableHeaderCell'
 import { WTableRow } from './TableRow'
 import { CellConfig, WTableProps } from './types'
-import { I18nNamespaces } from '../../../@types/i18next'
 
 export const WTable = <T extends StrapiModel>({
   data,
@@ -19,89 +16,44 @@ export const WTable = <T extends StrapiModel>({
   ...rest
 }: WTableProps<T>) => {
   const [sortMode, setSortMode] = useState<'desc' | 'asc' | null>(null)
-  const [selectedColumnKey, setSelectedColumnKey] = useState<string | null>(
-    null,
-  )
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
 
-  const selectedColumn = useMemo(() => {
-    return (
-      // TODO: What if there are multiple columns with the same key?
-      columns?.find(column => column.accessorKey === selectedColumnKey) ||
-      ({} as CellConfig<T>)
-    )
-  }, [selectedColumnKey, columns])
+  const selectedColumn = selectedIndex
+    ? columns[selectedIndex]
+    : ({} as CellConfig<T>)
 
-  const { t } = useTranslation()
-
-  const toggleSort = (columnKey: string) => {
-    setSelectedColumnKey(columnKey)
-
-    if (sortMode === 'asc') {
-      setSortMode('desc')
-    } else if (sortMode === 'desc') {
-      setSortMode(null)
-    } else {
-      setSortMode('asc')
-    }
-  }
+  const selectedKey = selectedColumn.accessorKey as string
 
   useEffect(() => {
     const { transform, sortKey } = selectedColumn
 
-    if (sortMode && selectedColumnKey) {
+    if (sortMode && selectedKey) {
       if (transform && sortKey) {
-        onSort?.([`${selectedColumnKey}.${sortKey}:${sortMode}`])
+        onSort?.([`${selectedKey}.${sortKey}:${sortMode}`])
       } else {
-        onSort?.([`${selectedColumnKey}:${sortMode}`])
+        onSort?.([`${selectedKey}:${sortMode}`])
       }
-    } else if (!sortMode && selectedColumnKey) {
+    } else if (!sortMode && selectedIndex) {
       onSort?.(undefined)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortMode, selectedColumnKey])
+  }, [sortMode, selectedIndex])
 
   return (
     <Table size="sm" cursor="default" {...rest}>
       <Thead pos={'sticky'} top={0} zIndex={0} h={8} bg={'white'} shadow={'sm'}>
         <Tr>
-          {Object.keys(columns).map((key, index) => {
-            const { sortable, label } = selectedColumn
-
-            const translationLabel = t(
-              (label || key) as keyof I18nNamespaces['common'],
-              {
-                defaultValue: label || startCase(camelCase(key)),
-              },
-            )
-
-            const getSortIcon = () => {
-              if (!sortable) return
-
-              if (selectedColumnKey === key) {
-                if (sortMode === 'asc') {
-                  return FaArrowUp
-                } else if (sortMode === 'desc') {
-                  return FaArrowDown
-                }
-              }
-
-              return FaSort
-            }
-
+          {columns.map((column, index) => {
             return (
-              <Th
-                pos="relative"
+              <TableHeaderCell
+                column={column}
+                index={index}
                 key={index}
-                whiteSpace="nowrap"
-                {...(sortable && {
-                  cursor: 'pointer',
-                  onClick: () => toggleSort(key as StrapiModelKeys),
-                })}
-              >
-                {translationLabel}
-
-                <chakra.span ml={2} display="inline" as={getSortIcon()} />
-              </Th>
+                selectedIndex={selectedIndex}
+                sortMode={sortMode}
+                setSelectedIndex={setSelectedIndex}
+                setSortMode={setSortMode}
+              />
             )
           })}
         </Tr>

--- a/packages/ui/src/components/WTable/WTableCell.tsx
+++ b/packages/ui/src/components/WTable/WTableCell.tsx
@@ -9,12 +9,13 @@ import { WTableCellProps } from './types'
 import { FormattedDate } from '../FormattedDate'
 
 export const WTableCell = <T extends StrapiModel>({
-  value,
-  cellConfig,
-  field,
+  column,
   model,
 }: WTableCellProps<T>) => {
-  const { type, transform, componentProps, cellProps } = cellConfig
+  const { accessorKey, type, transform, componentProps, cellProps } = column
+
+  const value = model[accessorKey]
+
   const data = (
     typeof transform === 'function'
       ? transform(value as T[keyof T], model)
@@ -52,7 +53,7 @@ export const WTableCell = <T extends StrapiModel>({
   return (
     <Td {...cellProps}>
       <Box
-        {...(field === 'description' && { noOfLines: 1, maxW: 120 })}
+        {...(accessorKey === 'description' && { noOfLines: 1, maxW: 120 })}
         noOfLines={1}
       >
         {cellContent || '-'}

--- a/packages/ui/src/components/WTable/types.ts
+++ b/packages/ui/src/components/WTable/types.ts
@@ -42,6 +42,15 @@ export type WTableCellProps<T extends StrapiModel> = {
   model: T
 }
 
+export type TableHeaderCellProps<T extends StrapiModel> = {
+  column: CellConfig<T>
+  index: number
+  selectedIndex: number | null
+  sortMode: 'asc' | 'desc' | null
+  setSelectedIndex: (index: number) => void
+  setSortMode: (mode: 'asc' | 'desc' | null) => void
+}
+
 export type WTableRowProps<T extends StrapiModel> = {
   columns: Array<CellConfig<T>>
   model: T

--- a/packages/ui/src/components/WTable/types.ts
+++ b/packages/ui/src/components/WTable/types.ts
@@ -27,6 +27,7 @@ type CellConfigCommon<T extends StrapiModel> =
   | CustomCell<'date', T, Partial<FormattedDateProps>>
 
 export type CellConfig<T extends StrapiModel> = CellConfigCommon<T> & {
+  accessorKey: keyof T
   cellProps?: TableCellProps
   label?: string
   sortable?: boolean // Currently not supported when transform is used
@@ -36,15 +37,13 @@ export type CellConfig<T extends StrapiModel> = CellConfigCommon<T> & {
 }
 
 export type WTableCellProps<T extends StrapiModel> = {
-  value: T[keyof T]
   // TODO Add specific type for each cell value
-  cellConfig: CellConfig<T>
-  field: keyof T
+  column: CellConfig<T>
   model: T
 }
 
 export type WTableRowProps<T extends StrapiModel> = {
-  columns: { [key in keyof T]?: CellConfig<T> }
+  columns: Array<CellConfig<T>>
   model: T
   modelIndex: number
   onClick?: (index: number, id: number) => void

--- a/packages/ui/src/hooks/tables/activity.tsx
+++ b/packages/ui/src/hooks/tables/activity.tsx
@@ -4,11 +4,12 @@ import { localeBadgesPDF, publicationBadgePDF } from './utils'
 import { LocaleBadges, PublicationBadges, WTableProps } from '../../components'
 
 export const useActivityColumns = (): WTableProps<Activity>['columns'] => {
-  return {
-    image: { type: 'image' },
-    title: { sortable: true },
-    description: {},
-    approvalStatus: {
+  return [
+    { accessorKey: 'image', type: 'image' },
+    { accessorKey: 'title', sortable: true },
+    { accessorKey: 'description' },
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -23,23 +24,27 @@ export const useActivityColumns = (): WTableProps<Activity>['columns'] => {
         }
       },
     },
-    translates: {
+    {
+      accessorKey: 'translates',
       transform: value => <LocaleBadges locales={value as StrapiLocale[]} />,
       transformPDF: value => localeBadgesPDF(value as StrapiLocale[]),
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-    date: {
+    {
+      accessorKey: 'date',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/archive-content.tsx
+++ b/packages/ui/src/hooks/tables/archive-content.tsx
@@ -10,16 +10,18 @@ export const useArchiveContentColumns =
   (): WTableProps<ArchiveContent>['columns'] => {
     const { locale } = useRouter()
 
-    return {
-      id: { sortable: true },
-      title: { sortable: true },
-      source: { sortable: true },
-      link: { sortable: true },
-      date: {
+    return [
+      { accessorKey: 'id', sortable: true },
+      { accessorKey: 'title', sortable: true },
+      { accessorKey: 'source', sortable: true },
+      { accessorKey: 'link', sortable: true },
+      {
+        accessorKey: 'date',
         type: 'date',
         sortable: true,
       },
-      categories: {
+      {
+        accessorKey: 'categories',
         transform: value => (
           <Wrap>
             {(value as Category[])
@@ -41,7 +43,8 @@ export const useArchiveContentColumns =
             ?.map(c => `[${c[`name_${locale}`]}]`)
             .join(', '),
       },
-      tags: {
+      {
+        accessorKey: 'tags',
         transform: value => (
           <Wrap>
             {(value as Tag[])?.map(t => (
@@ -54,11 +57,12 @@ export const useArchiveContentColumns =
         transformPDF: value =>
           (value as Tag[])?.map(t => `[${t[`name_${locale}`]}]`).join(', '),
       },
-      publishedAt: {
+      {
+        accessorKey: 'publishedAt',
         transform: value => (
           <PublicationBadges publishedAt={value as string | null} />
         ),
         transformPDF: value => publicationBadgePDF(value as string | null),
       },
-    }
+    ]
   }

--- a/packages/ui/src/hooks/tables/art.tsx
+++ b/packages/ui/src/hooks/tables/art.tsx
@@ -8,16 +8,25 @@ import { PublicationBadges, WTableProps } from '../../components'
 export const useArtColumns = (): WTableProps<Art>['columns'] => {
   const { locale } = useRouter()
 
-  return {
-    image: { type: 'image' },
-    [`title_${locale}`]: {},
-    [`description_${locale}`]: {},
-    artist: {
+  return [
+    {
+      accessorKey: 'image',
+      type: 'image',
+    },
+    {
+      accessorKey: `title_${locale}`,
+    },
+    {
+      accessorKey: `description_${locale}`,
+    },
+    {
+      accessorKey: 'artist',
       transform: value => (value as Profile)?.email,
       sortKey: 'email',
       sortable: true,
     },
-    approvalStatus: {
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -32,15 +41,17 @@ export const useArtColumns = (): WTableProps<Art>['columns'] => {
         }
       },
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/assets-trackings.tsx
+++ b/packages/ui/src/hooks/tables/assets-trackings.tsx
@@ -4,23 +4,30 @@ import { WTableProps } from '../../components'
 
 export const useAssetsTrackingsColumns =
   (): WTableProps<AssetsTracking>['columns'] => {
-    return {
-      fromLocation: {},
-      toLocation: {},
-      date: {
+    return [
+      {
+        accessorKey: 'fromLocation',
+      },
+      {
+        accessorKey: 'toLocation',
+      },
+      {
+        accessorKey: 'date',
         type: 'date',
         sortable: true,
       },
-      assignedTo: {
+      {
+        accessorKey: 'assignedTo',
         transform: value => {
           const profile = value as Profile
 
           return profile?.name || profile?.email
         },
       },
-      createdAt: {
+      {
+        accessorKey: 'createdAt',
         type: 'date',
         sortable: true,
       },
-    }
+    ]
   }

--- a/packages/ui/src/hooks/tables/assets.tsx
+++ b/packages/ui/src/hooks/tables/assets.tsx
@@ -7,24 +7,30 @@ import { WTableProps } from '../../components'
 export const useAssetsColumns = (): WTableProps<Asset>['columns'] => {
   const { locale } = useRouter()
 
-  return {
-    images: { type: 'image' },
-    sku: {},
-    name: { sortable: true },
-    location: {
+  return [
+    { accessorKey: 'images', type: 'image' },
+    { accessorKey: 'sku' },
+    { accessorKey: 'name', sortable: true },
+    {
+      accessorKey: 'location',
       sortable: true,
     },
-    price: {},
-    peopleInCharge: {
+    {
+      accessorKey: 'price',
+    },
+    {
+      accessorKey: 'peopleInCharge',
       transform: value =>
         (value as Profile[])?.map(person => person.name).join(', ') || '-',
     },
-    platform: {
+    {
+      accessorKey: 'platform',
       transform: value => (value as Platform)?.[`name_${locale}`] || '-',
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/blogs.tsx
+++ b/packages/ui/src/hooks/tables/blogs.tsx
@@ -4,16 +4,20 @@ import { publicationBadgePDF } from './utils'
 import { PublicationBadges, WTableProps } from '../../components'
 
 export const useBlogColumns = (): WTableProps<Blog>['columns'] => {
-  return {
-    image: { type: 'image' },
-    author: {
+  return [
+    { accessorKey: 'image', type: 'image' },
+    {
+      accessorKey: 'author',
       transform: value => (value as Profile)?.email,
       sortKey: 'email',
       sortable: true,
     },
-    title: { sortable: true },
-    description: {},
-    approvalStatus: {
+    { accessorKey: 'title', sortable: true },
+    {
+      accessorKey: 'description',
+    },
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -28,15 +32,17 @@ export const useBlogColumns = (): WTableProps<Blog>['columns'] => {
         }
       },
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/category.tsx
+++ b/packages/ui/src/hooks/tables/category.tsx
@@ -4,14 +4,15 @@ import { publicationBadgePDF } from './utils'
 import { PublicationBadges, WTableProps } from '../../components'
 
 export const useCategoryColumns = (): WTableProps<Category>['columns'] => {
-  return {
-    id: { sortable: true },
-    slug: { sortable: true },
-    publishedAt: {
+  return [
+    { accessorKey: 'id', sortable: true },
+    { accessorKey: 'slug', sortable: true },
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/collection.tsx
+++ b/packages/ui/src/hooks/tables/collection.tsx
@@ -4,12 +4,15 @@ import { localeBadgesPDF, publicationBadgePDF } from './utils'
 import { LocaleBadges, PublicationBadges, WTableProps } from '../../components'
 
 export const useCollectionColumns = (): WTableProps<Collection>['columns'] => {
-  return {
-    image: { type: 'image' },
-    title: { sortable: true },
-    slug: { label: 'Slug' },
-    description: {},
-    approvalStatus: {
+  return [
+    { accessorKey: 'image', type: 'image' },
+    { accessorKey: 'title', sortable: true },
+    { accessorKey: 'slug', label: 'Slug' },
+    {
+      accessorKey: 'description',
+    },
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -24,20 +27,26 @@ export const useCollectionColumns = (): WTableProps<Collection>['columns'] => {
         }
       },
     },
-    arts: { transform: value => (value as Art[])?.length },
-    translates: {
+    {
+      accessorKey: 'arts',
+      transform: value => (value as Art[])?.length,
+    },
+    {
+      accessorKey: 'translates',
       transform: value => <LocaleBadges locales={value as StrapiLocale[]} />,
       transformPDF: value => localeBadgesPDF(value as StrapiLocale[]),
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/course-application.tsx
+++ b/packages/ui/src/hooks/tables/course-application.tsx
@@ -9,9 +9,10 @@ import { calculateInstallments } from '../../components/ProfileSettings/Payment/
 
 export const useCourseApplicationColumns =
   (): WTableProps<CourseApplication>['columns'] => {
-    return {
-      name: { sortable: true },
-      approvalStatus: {
+    return [
+      { accessorKey: 'name', sortable: true },
+      {
+        accessorKey: 'approvalStatus',
         type: 'badge',
         componentProps: value => {
           const colorScheme = {
@@ -26,12 +27,19 @@ export const useCourseApplicationColumns =
           }
         },
       },
-      city: { sortable: true },
-      email: {},
-      phone: {},
-      country: { sortable: true },
-      installmentCount: {},
-      payments: {
+      { accessorKey: 'city', sortable: true },
+      {
+        accessorKey: 'email',
+      },
+      {
+        accessorKey: 'phone',
+      },
+      { accessorKey: 'country', sortable: true },
+      {
+        accessorKey: 'installmentCount',
+      },
+      {
+        accessorKey: 'payments',
         transform: (value, application) => {
           const payments = value as CourseApplication['payments']
 
@@ -72,7 +80,8 @@ export const useCourseApplicationColumns =
           return `${formatPrice(totalAmount)}`
         },
       },
-      hasPaid: {
+      {
+        accessorKey: 'hasPaid',
         transform: (value, application) => {
           const getPaidStatus = () => {
             if (value) return 'paid'
@@ -100,6 +109,6 @@ export const useCourseApplicationColumns =
         },
         transformPDF: value => paidBadgesPDF(value as boolean | null),
       },
-      course: { transform: value => (value as Course).title_nl },
-    }
+      { accessorKey: 'course', transform: value => (value as Course).title_nl },
+    ]
   }

--- a/packages/ui/src/hooks/tables/courses.tsx
+++ b/packages/ui/src/hooks/tables/courses.tsx
@@ -8,27 +8,35 @@ import { LocaleBadges, PublicationBadges, WTableProps } from '../../components'
 export const useCourseColumns = (): WTableProps<Course>['columns'] => {
   const { locale } = useRouter()
 
-  return {
-    image: { type: 'image' },
-    [`title_${locale}`]: {},
-    [`description_${locale}`]: {},
-    translates: {
+  return [
+    { accessorKey: 'image', type: 'image' },
+    {
+      accessorKey: `title_${locale}`,
+    },
+    {
+      accessorKey: `description_${locale}`,
+    },
+    {
+      accessorKey: 'translates',
       transform: value => <LocaleBadges locales={value as StrapiLocale[]} />,
       transformPDF: value => localeBadgesPDF(value as StrapiLocale[]),
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-    startDate: {
+    {
+      accessorKey: 'startDate',
       type: 'date',
       sortable: true,
     },
-    endDate: {
+    {
+      accessorKey: 'endDate',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/donation.tsx
+++ b/packages/ui/src/hooks/tables/donation.tsx
@@ -3,13 +3,15 @@ import { Donation } from '@fc/types'
 import { WTableProps } from '../../components'
 
 export const useDonationColumns = (): WTableProps<Donation>['columns'] => {
-  return {
-    email: { sortable: true },
-    createdAt: {
+  return [
+    { accessorKey: 'email', sortable: true },
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-    status: {
+    {
+      accessorKey: 'status',
       type: 'badge',
       componentProps: value => {
         return {
@@ -18,9 +20,10 @@ export const useDonationColumns = (): WTableProps<Donation>['columns'] => {
         }
       },
     },
-    amount: {
+    {
+      accessorKey: 'amount',
       sortable: true,
       transform: value => `${(value as number).toFixed(2)} €`,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/foundation.tsx
+++ b/packages/ui/src/hooks/tables/foundation.tsx
@@ -3,16 +3,27 @@ import { Foundation } from '@fc/types'
 import { WTableProps } from '../../components'
 
 export const useFoundationsColumns = (): WTableProps<Foundation>['columns'] => {
-  return {
-    name: { sortable: true },
-    email: {},
-    bank1: {},
-    IBAN1: {},
-    bank2: {},
-    IBAN2: {},
-    createdAt: {
+  return [
+    { accessorKey: 'name', sortable: true },
+    {
+      accessorKey: 'email',
+    },
+    {
+      accessorKey: 'bank1',
+    },
+    {
+      accessorKey: 'IBAN1',
+    },
+    {
+      accessorKey: 'bank2',
+    },
+    {
+      accessorKey: 'IBAN2',
+    },
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/hashtag.tsx
+++ b/packages/ui/src/hooks/tables/hashtag.tsx
@@ -15,14 +15,19 @@ import { LocaleBadges, PublicationBadges, WTableProps } from '../../components'
 export const useHashtagColumns = (): WTableProps<Hashtag>['columns'] => {
   const { locale } = useRouter()
 
-  return {
-    image: { type: 'image' },
-    title: { sortable: true },
-    platform: {
+  return [
+    { accessorKey: 'image', type: 'image' },
+    {
+      accessorKey: 'title',
+      sortable: true,
+    },
+    {
+      accessorKey: 'platform',
       sortable: true,
       transform: value => (value as Platform)?.[`name_${locale}`] || '',
     },
-    approvalStatus: {
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -37,25 +42,30 @@ export const useHashtagColumns = (): WTableProps<Hashtag>['columns'] => {
         }
       },
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-    posts: {
+    {
+      accessorKey: 'posts',
       transform: value => (value as Post[])?.length,
     },
-    mentions: {
+    {
+      accessorKey: 'mentions',
       transform: value => (value as Mention[])?.length,
     },
-    translates: {
+    {
+      accessorKey: 'translates',
       transform: value => <LocaleBadges locales={value as StrapiLocale[]} />,
       transformPDF: value => localeBadgesPDF(value as StrapiLocale[]),
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/notification.tsx
+++ b/packages/ui/src/hooks/tables/notification.tsx
@@ -4,9 +4,9 @@ import { WTableProps } from '../../components'
 
 export const useNotificationColumns =
   (): WTableProps<Notification>['columns'] => {
-    return {
-      id: { sortable: true },
-      title: { sortable: true },
-      message: { sortable: true },
-    }
+    return [
+      { accessorKey: 'id', sortable: true },
+      { accessorKey: 'title', sortable: true },
+      { accessorKey: 'message', sortable: true },
+    ]
   }

--- a/packages/ui/src/hooks/tables/payment.tsx
+++ b/packages/ui/src/hooks/tables/payment.tsx
@@ -7,24 +7,42 @@ import { WTableProps } from '../../components'
 export const usePaymentColumns = (): WTableProps<CoursePayment>['columns'] => {
   const { locale } = useRouter()
 
-  return {
-    profile: {
+  return [
+    {
+      accessorKey: 'profile',
       type: 'image',
       transform: value => (value as Profile)?.avatar as any,
     },
-    id: { sortable: true },
-    email: { sortable: true },
-    status: { sortable: true },
-    amount: { sortable: true, transform: value => `${value} €` },
-    installmentNumber: {},
-    paymentDatetime: {
+    {
+      accessorKey: 'id',
+      sortable: true,
+    },
+    {
+      accessorKey: 'email',
+      sortable: true,
+    },
+    {
+      accessorKey: 'status',
+      sortable: true,
+    },
+    {
+      accessorKey: 'amount',
+      sortable: true,
+      transform: value => `${value} €`,
+    },
+    {
+      accessorKey: 'installmentNumber',
+    },
+    {
+      accessorKey: 'paymentDatetime',
       sortable: true,
       type: 'date',
       componentProps() {
         return { format: 'dd MMMM yy - HH:mm' }
       },
     },
-    courseApplication: {
+    {
+      accessorKey: 'courseApplication',
       transform(value) {
         const courseApplication = value as CourseApplication
         const course = courseApplication.course
@@ -32,5 +50,5 @@ export const usePaymentColumns = (): WTableProps<CoursePayment>['columns'] => {
         return course?.[`title_${locale}`] ?? ''
       },
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/post.tsx
+++ b/packages/ui/src/hooks/tables/post.tsx
@@ -4,21 +4,28 @@ import { localeBadgesPDF, publicationBadgePDF } from './utils'
 import { LocaleBadges, PublicationBadges, WTableProps } from '../../components'
 
 export const usePostColumns = (): WTableProps<Post>['columns'] => {
-  return {
-    image: { type: 'image' },
-    hashtag: {
+  return [
+    {
+      accessorKey: 'image',
+      type: 'image',
+    },
+    {
+      accessorKey: 'hashtag',
       sortable: true,
       transform: value => (value as Hashtag)?.title,
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-    translates: {
+    {
+      accessorKey: 'translates',
       transform: value => <LocaleBadges locales={value as StrapiLocale[]} />,
       transformPDF: value => localeBadgesPDF(value as StrapiLocale[]),
     },
-    approvalStatus: {
+    {
+      accessorKey: 'approvalStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme = {
@@ -33,11 +40,12 @@ export const usePostColumns = (): WTableProps<Post>['columns'] => {
         }
       },
     },
-    publishedAt: {
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/profile.tsx
+++ b/packages/ui/src/hooks/tables/profile.tsx
@@ -12,12 +12,14 @@ export const useProfileColumns = (): WTableProps<
   const { t } = useTranslation()
   const { locale } = useRouter()
 
-  return {
-    avatar: {
+  return [
+    {
+      accessorKey: 'avatar',
       type: 'image',
     },
-    name: { sortable: true },
-    isVolunteer: {
+    { accessorKey: 'name', sortable: true },
+    {
+      accessorKey: 'isVolunteer',
       label: 'volunteer',
       type: 'badge',
       transform: value => (value ? t('volunteer') : null),
@@ -26,7 +28,8 @@ export const useProfileColumns = (): WTableProps<
         variant: 'outline',
       },
     },
-    profileStatus: {
+    {
+      accessorKey: 'profileStatus',
       type: 'badge',
       componentProps: value => {
         const colorScheme: Record<ProfileStatus, ThemeTypings['colorSchemes']> =
@@ -46,7 +49,8 @@ export const useProfileColumns = (): WTableProps<
         }
       },
     },
-    user: {
+    {
+      accessorKey: 'user',
       label: 'role',
       transform: value => (value as User)?.role?.name,
       sortable: true,
@@ -78,22 +82,24 @@ export const useProfileColumns = (): WTableProps<
         }
       },
     },
-    platforms: {
+    {
+      accessorKey: 'platforms',
       transform: value =>
         (value as Platform[])?.map(job => job[`name_${locale}`]).join(', '),
       sortable: true,
       sortKey: `slug`,
     },
-    jobs: {
+    {
+      accessorKey: 'jobs',
       transform: value =>
         (value as Job[])?.map(job => job[`name_${locale}`]).join(', '),
       sortable: true,
       sortKey: `slug`,
     },
-    email: { sortable: true },
-    availableHours: { sortable: true },
-    phone: {},
-    country: { sortable: true },
-    createdAt: { type: 'date', sortable: true },
-  }
+    { accessorKey: 'email', sortable: true },
+    { accessorKey: 'availableHours', sortable: true },
+    { accessorKey: 'phone' },
+    { accessorKey: 'country', sortable: true },
+    { accessorKey: 'createdAt', type: 'date', sortable: true },
+  ]
 }

--- a/packages/ui/src/hooks/tables/tag.tsx
+++ b/packages/ui/src/hooks/tables/tag.tsx
@@ -4,17 +4,33 @@ import { publicationBadgePDF } from './utils'
 import { PublicationBadges, WTableProps } from '../../components'
 
 export const useTagColumns = (): WTableProps<Tag>['columns'] => {
-  return {
-    id: { sortable: true },
-    slug: { sortable: true },
-    name_en: { sortable: true },
-    name_nl: { sortable: true },
-    name_tr: { sortable: true },
-    publishedAt: {
+  return [
+    {
+      accessorKey: 'id',
+      sortable: true,
+    },
+    {
+      accessorKey: 'slug',
+      sortable: true,
+    },
+    {
+      accessorKey: 'name_en',
+      sortable: true,
+    },
+    {
+      accessorKey: 'name_nl',
+      sortable: true,
+    },
+    {
+      accessorKey: 'name_tr',
+      sortable: true,
+    },
+    {
+      accessorKey: 'publishedAt',
       transform: value => (
         <PublicationBadges publishedAt={value as string | null} />
       ),
       transformPDF: value => publicationBadgePDF(value as string | null),
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/user.tsx
+++ b/packages/ui/src/hooks/tables/user.tsx
@@ -6,19 +6,28 @@ import { Role, User } from '@fc/types'
 import { WTableProps } from '../../components'
 
 export const useUserColumns = (): WTableProps<User>['columns'] => {
-  return {
-    username: { sortable: true },
-    email: { sortable: true },
-    role: {
+  return [
+    {
+      accessorKey: 'username',
+      sortable: true,
+    },
+    {
+      accessorKey: 'email',
+      sortable: true,
+    },
+    {
+      accessorKey: 'role',
       transform: value => (value as Role)?.name,
       sortable: true,
       sortKey: 'type',
     },
-    createdAt: {
+    {
+      accessorKey: 'createdAt',
       type: 'date',
       sortable: true,
     },
-    confirmed: {
+    {
+      accessorKey: 'confirmed',
       cellProps: {
         textAlign: 'center',
       },
@@ -30,12 +39,13 @@ export const useUserColumns = (): WTableProps<User>['columns'] => {
         ),
       transformPDF: value => (value ? 'Yes' : 'No'),
     },
-    blocked: {
+    {
+      accessorKey: 'blocked',
       cellProps: {
         textAlign: 'center',
       },
       transform: value => value && <Icon as={FaTimesCircle} color="red.500" />,
       transformPDF: value => (value ? 'Blocked' : 'Active'),
     },
-  }
+  ]
 }

--- a/packages/ui/src/hooks/tables/userFeedbacks.tsx
+++ b/packages/ui/src/hooks/tables/userFeedbacks.tsx
@@ -7,28 +7,36 @@ import { WTableProps } from '../../components/WTable'
 
 export const useUserFeedbacksColumns =
   (): WTableProps<UserFeedback>['columns'] => {
-    return {
-      comment: {},
-      point: {
+    return [
+      {
+        accessorKey: 'comment',
+      },
+      {
+        accessorKey: 'point',
         cellProps: { textAlign: 'center' },
         sortable: true,
       },
-      issueLink: {
+      {
+        accessorKey: 'issueLink',
         transform: value => value && <Icon as={FaCheck} />,
         transformPDF: value => (value ? 'Yes' : '-'),
         cellProps: { textAlign: 'center' },
       },
-      processed: {
+      {
+        accessorKey: 'processed',
         type: 'badge',
         transform: value => value && <Icon as={FaCheck} />,
         transformPDF: value => (value ? 'Yes' : '-'),
         cellProps: { textAlign: 'center' },
         sortable: true,
       },
-      createdAt: {
+      {
+        accessorKey: 'createdAt',
         type: 'date',
         sortable: true,
       },
-      site: {},
-    }
+      {
+        accessorKey: 'site',
+      },
+    ]
   }


### PR DESCRIPTION
### Description

Using the same key more than once is not possible with the current implementation. For instance, I would like to display the `username` and `role` data in the profile table. The data in both fields comes from `profile.user`.

### Changes

Updates column configuration using array notation instead of object notation, similar to the react-table library.

### Notes

Migrating WTable to internally use React-table in the future would be nice. There are tons of advanced features in this library. But we should consider that the table data is always based on the backend response.